### PR TITLE
Corrigir bugs de ordenamento da lista no dicionário do Edivox

### DIFF
--- a/src/tradutor/DVDIC.PAS
+++ b/src/tradutor/DVDIC.PAS
@@ -348,6 +348,7 @@ var
     begin
         sl := TStringList.Create;
         s := d.sufixo;
+        listaSufixos.sorted := true;
         while s <> '' do
             begin
                 p := pos (' ', s);
@@ -377,6 +378,8 @@ var
 begin
    procuraDic := false;
    prefixoPalavra := palavra;
+   listaNomes.sorted := true;
+   listaInexist.sorted := true;
 
    if listaNomes.find (palavra, i) then
        begin
@@ -482,4 +485,3 @@ begin
 end;
 
 end.
-


### PR DESCRIPTION
Este PR se destina a corrigir bugs introduzidos na compilação com FPC do Edivox. Quando o dicionário era chamado, o edivox abortava com uma exception dizendo que a lista não estava ordenada. Não se sabe o porquê exatamente desses erros terem acontecido, mas como correção deste PR, foi colocada a flag sorted como true nas chamadas que o Edivox faz do dicionário, para forçar o programa a ordenar manualmente antes de fazer a busca. Foi também criado um PR no repositório do edivox (HTTPS://github.com/JosielSantos/edivox/pull/15) para incorporar esta correção.